### PR TITLE
Add advanced scripts. Multiple environments are supported, first-service status can be easily queried.

### DIFF
--- a/services/first-service/server-start.sh
+++ b/services/first-service/server-start.sh
@@ -1,7 +1,22 @@
 #!/bin/bash
 repo_directory=$(git rev-parse --show-toplevel)
-echo "Repo directory is ${repo_directory}. Starting first-service"
 cd ${repo_directory}/services/first-service
+
+if [ "$#" -ne 1 ]; then
+	echo "Usage: ./first-service.sh <environment name>"
+	exit
+elif [[ $1 == "prod" ]]; then
+	echo "Starting as production"
+	export APP_ENV="PRODUCTION"
+elif [[ $1 == "dev" ]]; then
+	echo "Starting in development"
+	export APP_ENV="DEVELOPMENT"
+else
+	echo "Current environments are 'prod' and 'dev'"
+	exit
+fi
+
+echo "Starting first-service with environment ${APP_ENV}"
 
 # Starts main.js under the name "first-service". Redirects all output
 #  to output.log and then resumes execution

--- a/services/first-service/server-status.sh
+++ b/services/first-service/server-status.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+# Prints status of the first-service process, including its APP_ENV variable.
+# Returns 0 if it the service is running, 1 otherwise.
+
+output=$(pgrep first-service);
+if [ $? -eq 0 ]; then # True if GREP finds a match. This relies on the exit-code variable, will fail if anything goes between `output=...` and this line.
+	app_env=$(xargs -n 1 -0 < /proc/${output}/environ | grep APP_ENV) # Get environment variables of process, locate the one labeled APP_ENV
+	echo "Service running with PID ${output} and ${app_env}"
+	exit 0
+else
+	echo "Service stopped"
+	exit 1
+fi

--- a/services/first-service/src/main.ts
+++ b/services/first-service/src/main.ts
@@ -8,14 +8,20 @@ process.title = ""; // Set no name, server-start.sh sets one for us.
 
 let HOST: string;
 let PORT: number;
-if(process.env.PRODUCTION === undefined) {
-	console.log("Not in production");
-	HOST = "127.0.0.1";
-	PORT = 3000;
-} else {
-	console.log("In production");
-	HOST = "10.0.0.6";
-	PORT = 3000;
+switch(process.env.APP_ENV) {
+	case "PRODUCTION":
+		console.log("Started as Production");
+		HOST = "10.0.0.6";
+		PORT = 3000;
+	break;
+	case "DEVELOPMENT":	
+		console.log("Started as Development");
+		HOST = "127.0.0.1";
+		PORT = 3000;
+	break;
+	default:
+		console.log(`Unknown environment ${process.env.APP_ENV}`);
+		process.exit(1)
 };
 
 app.get('/', (req: Request, res: Response) => {


### PR DESCRIPTION
On linux (maybe Unix as well?), first-service can be started (from services/first-service) with `./server-start.sh dev`
The status of the service can be queried with `./server-status.sh`
The service can be stopped with `./server-stop`.
