### PR TITLE
Bug fix auth redirects

### DIFF
--- a/services/first-service/.env.example
+++ b/services/first-service/.env.example
@@ -1,7 +1,9 @@
-# google client id and jwt secret can be found at /multi_service_sign_in/src/auth.ts
-# shouldn't use those in prod
-GOOGLE_CLIENT_ID= 
-JWT_SECRET=
+# example jwt secret can be found at /multi_service_sign_in/src/auth.ts
+# DO NOT USE IN PROD
+GOOGLE_CLIENT_ID="234677186525-7pptsu7ec995iiukijg38pqp00rg08u1.apps.googleusercontent.com"
+# LOGIN_URI="https://test.goodecodes.com/auth" # in production
+# LOGIN_URI="https://localhost:3000/auth" # in testing
+JWT_SECRET= # Secret used to sign the auth JWTs
 JWT_EXPIRY=900 # (15 minutes)
 MONGO_URI=mongodb://10.0.0.5
 PRODUCTION=

--- a/services/first-service/data/index.html
+++ b/services/first-service/data/index.html
@@ -9,7 +9,7 @@ temp
      data-client_id="{{ CLIENT_ID }}"
      data-context="use"
      data-ux_mode="popup"
-     data-login_uri="https://localhost:3000/auth"
+     data-login_uri="{{ LOGIN_URI }}"
      data-auto_prompt="false">
 </div>
 

--- a/services/first-service/data/index.html
+++ b/services/first-service/data/index.html
@@ -6,7 +6,7 @@
 <body>
 temp
 <div id="g_id_onload"
-     data-client_id="234677186525-7pptsu7ec995iiukijg38pqp00rg08u1.apps.googleusercontent.com"
+     data-client_id="{{ CLIENT_ID }}"
      data-context="use"
      data-ux_mode="popup"
      data-login_uri="https://localhost:3000/auth"

--- a/services/first-service/src/main.ts
+++ b/services/first-service/src/main.ts
@@ -13,9 +13,6 @@ import fs from "fs";
 
 dotenv.config();
 
-const key = fs.readFileSync("./certs/authkey.pem");
-const cert = fs.readFileSync("./certs/authcert.pem");
-
 const app = express();
 app.use(express.json())
 app.use(cookieParser());
@@ -38,20 +35,29 @@ const options: SignOptions = {
   expiresIn: Number(process.env.JWT_EXPIRY) // in seconds.
 }
 
+// Generic runtime parameters
+const PATH_THIS_FILE = import.meta.dirname;
+
 process.title = ""; // Set no name, server-start.sh sets one for us.
 
 let HOST: string;
 let PORT: number;
+let key;
+let cert;
 switch(process.env.APP_ENV) {
 	case "PRODUCTION":
 		console.log("Started as Production");
 		HOST = "10.0.0.6";
 		PORT = 3000;
+    key = fs.readFileSync("/prod/certs/first-service.key"); // /services/first-service/src/main.ts -> /tools/dev-certs/devcert1.key
+    cert = fs.readFileSync("/prod/certs/first-service.crt");
 	break;
 	case "DEVELOPMENT":	
 		console.log("Started as Development");
 		HOST = "127.0.0.1";
 		PORT = 3000;
+    key = fs.readFileSync(path.resolve(PATH_THIS_FILE, "../../../tools/dev-certs/devcert1.key")); // /services/first-service/src/main.ts -> /tools/dev-certs/devcert1.key
+    cert = fs.readFileSync(path.resolve(PATH_THIS_FILE, "../../../tools/dev-certs/devcert1.crt"));
 	break;
 	default:
 		console.log(`Unknown environment ${process.env.APP_ENV}`);
@@ -67,7 +73,7 @@ app.get('/test-auth', requireAuth, (req: Request, res: Response) => {
 });
 
 app.get('/auth', (req: Request, res: Response) => {
-	res.sendFile("./data/index.html", {root: path.resolve(import.meta.dirname, "../")});
+	res.sendFile("./data/index.html", {root: path.resolve(PATH_THIS_FILE, "../")});
 });
 
 app.post('/auth', async (req: Request, res: Response) => {

--- a/services/first-service/src/main.ts
+++ b/services/first-service/src/main.ts
@@ -64,8 +64,10 @@ switch(process.env.APP_ENV) {
 		process.exit(1)
 };
 
+const LOGIN_URI = process.env.LOGIN_URI!;
 const indexPageTemplate = fs.readFileSync(path.resolve(PATH_THIS_FILE,"../data/index.html"), {encoding: "utf-8"});
-const indexPage = indexPageTemplate.replaceAll(/[{]{2}\s*CLIENT_ID\s*[}]{2}/g, CLIENT_ID);
+const indexPage = indexPageTemplate.replaceAll(/[{]{2}\s*CLIENT_ID\s*[}]{2}/g, CLIENT_ID)
+                                   .replaceAll(/[{]{2}\s*LOGIN_URI\s*[}]{2}/g, LOGIN_URI);
 
 app.get('/', (req: Request, res: Response) => {
     res.send("Typescript with express!");

--- a/services/first-service/src/main.ts
+++ b/services/first-service/src/main.ts
@@ -64,6 +64,9 @@ switch(process.env.APP_ENV) {
 		process.exit(1)
 };
 
+const indexPageTemplate = fs.readFileSync(path.resolve(PATH_THIS_FILE,"../data/index.html"), {encoding: "utf-8"});
+const indexPage = indexPageTemplate.replaceAll(/[{]{2}\s*CLIENT_ID\s*[}]{2}/g, CLIENT_ID);
+
 app.get('/', (req: Request, res: Response) => {
     res.send("Typescript with express!");
 });
@@ -73,7 +76,7 @@ app.get('/test-auth', requireAuth, (req: Request, res: Response) => {
 });
 
 app.get('/auth', (req: Request, res: Response) => {
-	res.sendFile("./data/index.html", {root: path.resolve(PATH_THIS_FILE, "../")});
+	res.send(indexPage);
 });
 
 app.post('/auth', async (req: Request, res: Response) => {


### PR DESCRIPTION
Fixes #48
main.ts now inserts `data-login_uri` directly into index.html. This is the root cause of issue #48, along with a misconfiguration on the google OAuth platform (login_uri s must be authorized). main.ts now inserts `data-client_id` directly into index.html. While this isn't necessary yet, it will be useful if we follow the recommended practice of having different client IDs for development and production.