### PR TITLE
Bugfix: process name not being set

### DIFF
--- a/services/first-service/server-start.sh
+++ b/services/first-service/server-start.sh
@@ -18,6 +18,7 @@ fi
 
 echo "Starting first-service with environment ${APP_ENV}"
 
-# Starts main.js under the name "first-service". Redirects all output
+# Starts main.js, which sets its own name to "first-service". Redirects all output
 #  to output.log and then resumes execution
-exec -a first-service node build/main.js -- > output.log &
+# We will need to change the < /dev/null portion later if we wish to provide command line input to the running process
+setsid node build/main.js > output.log 2>&1 < /dev/null &

--- a/services/first-service/src/main.ts
+++ b/services/first-service/src/main.ts
@@ -82,7 +82,7 @@ app.get('/test-auth', requireAuth, (req: Request, res: Response) => {
 });
 
 app.get('/auth', (req: Request, res: Response) => {
-	res.sendFile("./data/index.html", {root: path.resolve(PATH_THIS_FILE, "../")});
+	res.send(indexPage);
 });
 
 app.post('/auth', async (req: Request, res: Response) => {

--- a/services/first-service/src/main.ts
+++ b/services/first-service/src/main.ts
@@ -11,6 +11,12 @@ import { connectToDb, closeDb } from "./db.js";
 import https from "https";
 import fs from "fs";
 
+// I would rather the process title be set in the startup script, but we haven't gotten that working reliably.
+// My gut says this service should have little to no concept of what the process title is, because it doesn't yet need
+//  to know or change it outside of this bug fix. Because the process name is needed by the status and stop scripts,
+//  ideally it should be created by the startup script so we can package/reuse the scripts for other services.
+// Currently we have to rely on setting the process title here and hoping that it matches the status and stop scripts.
+process.title = "first-service"
 dotenv.config();
 
 const app = express();
@@ -37,8 +43,6 @@ const options: SignOptions = {
 
 // Generic runtime parameters
 const PATH_THIS_FILE = import.meta.dirname;
-
-process.title = ""; // Set no name, server-start.sh sets one for us.
 
 let HOST: string;
 let PORT: number;


### PR DESCRIPTION
closes #29, relies on features from #44.
`./server-start.sh` and `main.ts` now set the process name on startup so that the `./server-status.sh` and `./server-stop.sh` commands work on the production server.
