### PR TITLE
Added GET guilds/{guildID} solves #86

### DIFF
--- a/services/first-service/data/index.html
+++ b/services/first-service/data/index.html
@@ -303,7 +303,7 @@
                if (!me) {
                     setStatus({ kind: "error", msg: "Not authenticated. Please sign in again." });
                     window.location.hash = "#/login";
-                    return;
+                    return; 
                }
 
                setUser(me);

--- a/services/first-service/src/db.ts
+++ b/services/first-service/src/db.ts
@@ -1,4 +1,5 @@
 import { MongoClient, type Collection, type Db } from "mongodb";
+import type { Document } from "mongodb";
 
 let client: MongoClient | null = null;
 let db: Db | null = null;
@@ -22,8 +23,9 @@ export function getDb() {
 }
 
 // should be changed later prolly to add generics for type safety, for now though it just returns document
-export function getCollection(name: string): Collection {
-    return getDb().collection(name);
+// changed to support generics, needed to define interface in guilds.ts
+export function getCollection<T extends Document = Document>(name: string) { // default generic is document
+    return getDb().collection<T>(name);
 }
 
 export async function closeDb() {

--- a/services/first-service/src/guilds.ts
+++ b/services/first-service/src/guilds.ts
@@ -1,0 +1,48 @@
+import { Router } from 'express';
+import type { Request, Response } from 'express';
+import { requireAuth } from './middleware.js';
+import { getCollection, isDbConnected } from './db.js';
+
+interface Guild {
+    _id: string;
+    friendlyName: string;
+    members: string[];
+    channels: [{ friendlyName: string; _id: string }];
+}
+
+const router = Router();
+
+// :guildID is the route parameter, otherwise we would do /guilds?guildID=123
+// 401 code is handled by requireAuth
+router.get('/guilds/:guildID', requireAuth, async (req: Request, res: Response) => {
+    if (!isDbConnected()) {
+        // NOTE: Issue says 503 if query failed due to timed out, db offline, etc.
+        // but sprint2plan says 503 if can't connect to db, 500 otherwise
+        // ill follow sprint2plan but lmk if it should be changed
+        res.status(503).json({ error: "database not connected" });
+        return;
+    }
+    const guildID = req.params.guildID;
+    // confirm it is string for mongodb, have to do or else ts error
+    if (!guildID || typeof guildID !== 'string') {
+        // added 400 code, better suited for this error (bad request)
+        res.status(400).json({ error: "guildID is required and must be a string" });
+        return;
+    }
+    try {
+        // mongodb expects _id to be objectID generically
+        // however in db it is actually string
+        // so we have to define interface to avoid typescript error
+        const guild = await getCollection<Guild>("guilds").findOne({ _id: guildID });
+        if (!guild) {
+            res.status(404).json({ error: "guild not found" });
+            return;
+        }
+        res.status(200).json(guild);
+    } catch (err) {
+        console.log("Error fetching guild:", err);
+        res.status(500).json({ error: "failed to fetch guild" });
+    }
+});
+
+export default router;

--- a/services/first-service/src/main.ts
+++ b/services/first-service/src/main.ts
@@ -11,6 +11,7 @@ import { connectToDb, closeDb, isDbConnected } from "./db.js";
 import https from "https";
 import fs from "fs";
 import messageRoutes, { initMessages } from "./messages.js";
+import guildRoutes from "./guilds.js";
 
 // I would rather the process title be set in the startup script, but we haven't gotten that working reliably.
 // My gut says this service should have little to no concept of what the process title is, because it doesn't yet need
@@ -25,6 +26,7 @@ app.use(express.json())
 app.use(cookieParser());
 app.use(express.urlencoded({ extended: true })); // parse URL-encoded bodies for google
 app.use(messageRoutes); // use the message routes defined in messages.ts
+app.use(guildRoutes); // use the guild routes defined in guilds.ts
 
 // Google JWT verification
 const CLIENT_ID = process.env.GOOGLE_CLIENT_ID!;

--- a/services/first-service/src/messages.ts
+++ b/services/first-service/src/messages.ts
@@ -3,6 +3,7 @@ import type { Request, Response } from 'express';
 import { requireAuth } from './middleware.js';
 import { getCollection, isDbConnected } from './db.js';
 
+
 // using router since we are not in main.ts, then export the router to be used in main.ts
 const router = Router();
 let lastMsgId: number = 0;


### PR DESCRIPTION
NOTE: POST guilds should send the guild using the schema defined in sprint2plan.md. If any types are off or fields names are different, this endpoint will break.

Testing: Tested minimally ensuring auth works, 503 error works, 404 error works. I confirmed that it does try to search for a guild in db without throwing error.

More testing is needed in the future, but as POST guilds is not defined yet the db is not populated with any entries for the guilds collection, and as such I cannot test a successful search. (I could go into mongo shell and manually add an entry, but considering this isn't in production yet and GET guilds is not accessed in UI, we can test this once POST has been implemented).

Note: I am unsure how to test the 400 error checking if the string is valid. I don't know how to pass a non-string or empty string as an argument.